### PR TITLE
TASK: Switch image with asset editor

### DIFF
--- a/Classes/CreationDialogPostprocessor.php
+++ b/Classes/CreationDialogPostprocessor.php
@@ -86,10 +86,25 @@ class CreationDialogPostprocessor implements NodeTypePostprocessorInterface
         if (isset($configuration['validation'])) {
             $convertedConfiguration['validation'] = $configuration['validation'];
         }
+
         $convertedConfiguration['ui']['editor'] = $configuration['ui']['inspector']['editor'] ?? 'Neos.Neos/Inspector/Editors/TextFieldEditor';
+
+        if ($convertedConfiguration['ui']['editor'] == 'Neos.Neos/Inspector/Editors/ImageEditor') {
+            $convertedConfiguration['ui']['editor'] = 'Neos.Neos/Inspector/Editors/AssetEditor';
+
+            if (!isset($configuration['ui']['inspector']['editorOptions']['accept'])) {
+                $convertedConfiguration['ui']['editorOptions']['accept'] = 'image/*';
+            }
+        }
+
         if (isset($configuration['ui']['inspector']['editorOptions'])) {
             $convertedConfiguration['ui']['editorOptions'] = $configuration['ui']['inspector']['editorOptions'];
         }
+
+        if ($convertedConfiguration['ui']['editor'] == 'Neos.Neos/Inspector/Editors/AssetEditor') {
+            $convertedConfiguration['ui']['editorOptions']['features']['mediaBrowser'] = false;
+        }
+
         return $convertedConfiguration;
     }
 }


### PR DESCRIPTION
This solves issue #6 
* If the editor is set to the image editor, it will be switched to the asset editor
* If the editor option `accept` is not set, it will be set to `image/*`
* On all asset editors the media browser will set to false, as this is not a supported feature